### PR TITLE
Do not use bind in read and write for better performance.

### DIFF
--- a/read.js
+++ b/read.js
@@ -1,15 +1,18 @@
 var proto = {}
   , rex = /read.+/
-  , fn
+  , buildFn
 
-fn = function() {
+buildFn = function(key) {
+  var code = '' +
+    'return buf.' + key + '(' + ['a', 'b', 'c'].join(',' ) + ')'
 
+  return new Function(['buf', 'a', 'b', 'c'], code)
 }
 
 module.exports = proto
 
 for(var key in Buffer.prototype) {
   if(rex.test(key)) {
-    proto[key] = fn.call.bind(Buffer.prototype[key])
+    proto[key] = buildFn(key)
   }
 }

--- a/write.js
+++ b/write.js
@@ -2,16 +2,19 @@ var Buffer = require('buffer').Buffer
 
 var proto = {}
   , rex = /write.+/
-  , fn
+  , buildFn
 
-fn = function() {
+buildFn = function(key) {
+  var code = '' +
+    'return buf.' + key + '(' + ['a', 'b', 'c'].join(',' ) + ')'
 
+  return new Function(['buf', 'a', 'b', 'c'], code)
 }
 
 module.exports = proto
 
 for(var key in Buffer.prototype) {
   if(rex.test(key)) {
-    proto[key] = fn.call.bind(Buffer.prototype[key])
+    proto[key] = buildFn(key)
   }
 }


### PR DESCRIPTION
This pull-request remove the use of bind in the `read*` and `write*` method in node.js versions of bops.
This is particularly needed by high-performance node modules, such as the levelup community.

I tested this using this benchmark:

``` js
var bops = require('./')
  , buf = new Buffer('hello world')
  , start
  , stop
  , count = 1000000

for (var i = 0; i < count; i++) {
  buf.readUInt8(2)
  bops.readUInt8(buf, 2)
}

start = process.hrtime()

for (var i = 0; i < count; i++) {
  buf.readUInt8(2)
}

stop = process.hrtime()

console.log(stop[0] - start[0], stop[1] - start[1])

start = process.hrtime()

for (var i = 0; i < count; i++) {
  bops.readUInt8(buf, 2)
}

stop = process.hrtime()

console.log(stop[0] - start[0], stop[1] - start[1])
```

Before the patch:

```
Buffer 0 19513627
bops 0 253252617
```

After the patch:

```
Buffer 0 19685158
bops 0 19825163
```
