### PR TITLE
Update base64-js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "tape": "~2.0.0"
   },
   "dependencies": {
-    "base64-js": "0.0.2",
+    "base64-js": "1.0.2",
     "to-utf8": "0.0.1"
   },
   "testling": {


### PR DESCRIPTION
My team is preparing software for distribution, and we need to make sure all the dependencies have licenses. I’m using [license-checker](https://github.com/davglass/license-checker) to verify all the modules’ licenses, and it’s complaining about bops’ [base64-js](https://www.npmjs.com/package/base64-js) dependency (0.0.2!), which lacks a license.

Updating to the latest base64-js (1.0.2) includes the wonderful MIT license. Also, all bops’ tests pass!

![bops-tests](https://cloud.githubusercontent.com/assets/1858316/12341539/47b7b018-bad7-11e5-834c-f2dc05348271.jpg)
